### PR TITLE
Add more articles list to article pages

### DIFF
--- a/src/_layouts/article.njk
+++ b/src/_layouts/article.njk
@@ -29,7 +29,7 @@ layout: base.njk
     <h2 class="c-article__more-title">More articles</h2>
     <ol class="c-article__more-list o-list-bare">
       {% for post in allPosts %}
-      <li class="c-article__more-item{% if post.url == page.url %} is-active{% endif %}">
+      <li class="c-article__more-item{% if post.url == page.url %} c-article__more-item--is-active{% endif %}">
         {% if post.url == page.url %}
           <span class="c-article__more-item-title">{{ post.title }}</span>
         {% else %}

--- a/src/_layouts/article.njk
+++ b/src/_layouts/article.njk
@@ -24,4 +24,20 @@ layout: base.njk
   <footer class="c-article__footer">
     <a href="/" class="c-article__back-link">← Back to home</a>
   </footer>
+
+  <nav class="c-article__more">
+    <h2 class="c-article__more-title">More articles</h2>
+    <ol class="c-article__more-list o-list-bare">
+      {% for post in allPosts %}
+      <li class="c-article__more-item{% if post.url == page.url %} is-active{% endif %}">
+        {% if post.url == page.url %}
+          <span class="c-article__more-item-title">{{ post.title }}</span>
+        {% else %}
+          <a class="c-article__more-item-title" href="{{ post.url }}">{{ post.title }}</a>
+        {% endif %}
+        <time class="c-article__more-item-date">{{ post.date }}</time>
+      </li>
+      {% endfor %}
+    </ol>
+  </nav>
 </article>

--- a/src/styles/components/_article.scss
+++ b/src/styles/components/_article.scss
@@ -306,21 +306,22 @@
   justify-content: space-between;
   align-items: baseline;
   gap: var(--s-3);
-  padding-block: var(--s-2);
+  padding-block: var(--s-1);
   border-block-start: 1px solid var(--c-decorative);
 
-  &.is-active {
-    color: var(--c-text-subdued);
+  @include mq.mq($from: md) {
+    padding-block: var(--s-2);
   }
+}
+
+.c-article__more-item--is-active {
+  color: var(--c-text-subdued);
+  font-style: italic;
 }
 
 .c-article__more-item-title {
   font-size: var(--base-font-size);
   flex: 1;
-
-  .is-active & {
-    font-style: italic;
-  }
 }
 
 .c-article__more-item-date {

--- a/src/styles/components/_article.scss
+++ b/src/styles/components/_article.scss
@@ -281,3 +281,51 @@
     text-decoration-color: var(--c-decorative);
   }
 }
+
+/*------------------------------------*\
+    # ARTICLE MORE
+\*------------------------------------*/
+
+.c-article__more {
+  max-width: 680px;
+  margin-inline: auto;
+  margin-block-start: var(--s-8);
+}
+
+.c-article__more-title {
+  font-size: var(--h5);
+  margin-block-start: 0;
+}
+
+.c-article__more-list {
+  margin-block-start: var(--s-3);
+}
+
+.c-article__more-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--s-3);
+  padding-block: var(--s-2);
+  border-block-start: 1px solid var(--c-decorative);
+
+  &.is-active {
+    color: var(--c-text-subdued);
+  }
+}
+
+.c-article__more-item-title {
+  font-size: var(--base-font-size);
+  flex: 1;
+
+  .is-active & {
+    font-style: italic;
+  }
+}
+
+.c-article__more-item-date {
+  font-size: var(--small);
+  color: var(--c-text-subdued);
+  white-space: nowrap;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary

- Adds a "More articles" list to the bottom of every article page to encourage onward reading
- Loops over `allPosts` (existing global data file) so both internal and external articles are included
- Current article is marked with `c-article__more-item--is-active` (italic, subdued colour) and rendered as a `<span>` rather than a link
- Mobile-first padding: `--s-1` default, `--s-2` from `md` breakpoint

## Test plan

- [ ] Open an internal article page and confirm the list appears at the bottom
- [ ] Confirm the current article is italicised and greyed out, with no link
- [ ] Confirm all other articles link correctly, including external ones
- [ ] Open a second article and confirm the active state shifts to the correct item
- [ ] Check on mobile that spacing looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)