### PR TITLE
Add reading progress bar to article pages

### DIFF
--- a/src/_layouts/article.njk
+++ b/src/_layouts/article.njk
@@ -2,6 +2,7 @@
 layout: base.njk
 ---
 <article class="c-article">
+  <div class="c-progress-bar" aria-hidden="true"></div>
   <header class="c-article__header">
     <h1 class="c-article__title">{{ title }}</h1>
     {% if subtitle %}
@@ -41,3 +42,42 @@ layout: base.njk
     </ol>
   </nav>
 </article>
+
+<script>
+(() => {
+  const bar = document.querySelector('.c-progress-bar');
+  const content = document.querySelector('.c-article__content');
+  if (!bar || !content) return;
+
+  let ticking = false;
+
+  const updateProgress = () => {
+    const rect = content.getBoundingClientRect();
+    const contentTop = rect.top + window.scrollY;
+    const contentHeight = rect.height;
+    const viewportHeight = window.innerHeight;
+
+    const start = contentTop;
+    const end = contentTop + contentHeight - viewportHeight;
+
+    if (end <= start) {
+      bar.style.opacity = '0';
+      ticking = false;
+      return;
+    }
+
+    const progress = Math.min(Math.max((window.scrollY - start) / (end - start), 0), 1);
+    bar.style.transform = `scaleX(${progress})`;
+    ticking = false;
+  };
+
+  window.addEventListener('scroll', () => {
+    if (!ticking) {
+      requestAnimationFrame(updateProgress);
+      ticking = true;
+    }
+  }, { passive: true });
+
+  updateProgress();
+})();
+</script>

--- a/src/styles/components/_progress-bar.scss
+++ b/src/styles/components/_progress-bar.scss
@@ -1,0 +1,13 @@
+.c-progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background-color: var(--c-text-highlight);
+  transform: scaleX(0);
+  transform-origin: left;
+  z-index: 9999;
+  pointer-events: none;
+  will-change: transform;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -28,6 +28,7 @@
 @use 'components/social-links';
 @use 'components/archive';
 @use 'components/article';
+@use 'components/progress-bar';
 
 @use 'utilities/clearfix';
 @use 'utilities/visibility';


### PR DESCRIPTION
## Summary

- Adds a fixed reading progress bar at the top of article pages that fills as the reader scrolls through the content
- Uses GPU-accelerated `scaleX` transform with `requestAnimationFrame` throttling for smooth, jank-free performance
- Adapts to light/dark theme automatically via the existing `--c-text-highlight` token

## Test plan

- [x] Navigate to any article page and scroll — bar should fill from 0% to 100%
- [x] Toggle theme — bar color should adapt
- [x] Check a short article — bar should be hidden if content fits in viewport
- [x] Verify production build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)