### PR TITLE
Add copyable heading anchors to blog articles

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,5 +1,6 @@
 import markdownItImageFigures from 'markdown-it-image-figures';
 import markdownItAttrs from 'markdown-it-attrs';
+import markdownItAnchor from 'markdown-it-anchor';
 import { eleventyImageTransformPlugin } from '@11ty/eleventy-img';
 import Image from '@11ty/eleventy-img';
 import path from 'path';
@@ -18,6 +19,16 @@ export default function(eleventyConfig) {
     mdLib.use(markdownItImageFigures, {
       figcaption: 'title',  // Use title attribute for caption, preserving alt text
       copyAttrs: 'class'    // Copy class attributes to figure element
+    });
+    mdLib.use(markdownItAnchor, {
+      level: [2, 3, 4],
+      permalink: markdownItAnchor.permalink.linkInsideHeader({
+        class: 'c-heading-anchor',
+        symbol: '<svg class="c-heading-anchor__icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>',
+        placement: 'before',
+        ariaHidden: false,
+        renderAttrs: () => ({ 'aria-label': 'Copy link to this section' }),
+      }),
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@11ty/eleventy-img": "6.0.4",
     "gray-matter": "4.0.3",
     "html-minifier-terser": "7.2.0",
+    "markdown-it-anchor": "9.2.0",
     "markdown-it-attrs": "4.3.1",
     "markdown-it-image-figures": "2.1.1",
     "npm-run-all": "4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       html-minifier-terser:
         specifier: 7.2.0
         version: 7.2.0
+      markdown-it-anchor:
+        specifier: 9.2.0
+        version: 9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.1.0)
       markdown-it-attrs:
         specifier: 4.3.1
         version: 4.3.1(markdown-it@14.1.0)
@@ -300,6 +303,15 @@ packages:
   '@sindresorhus/transliterate@1.6.0':
     resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
     engines: {node: '>=12'}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   a-sync-waterfall@1.0.1:
     resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==}
@@ -948,6 +960,12 @@ packages:
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
+
+  markdown-it-anchor@9.2.0:
+    resolution: {integrity: sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==}
+    peerDependencies:
+      '@types/markdown-it': '*'
+      markdown-it: '*'
 
   markdown-it-attrs@4.3.1:
     resolution: {integrity: sha512-/ko6cba+H6gdZ0DOw7BbNMZtfuJTRp9g/IrGIuz8lYc/EfnmWRpaR3CFPnNbVz0LDvF8Gf1hFGPqrQqq7De0rg==}
@@ -1748,6 +1766,15 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   a-sync-waterfall@1.0.1: {}
 
   acorn-walk@8.3.4:
@@ -2451,6 +2478,11 @@ snapshots:
       tslib: 2.8.1
 
   luxon@3.7.2: {}
+
+  markdown-it-anchor@9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.1.0):
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.0
 
   markdown-it-attrs@4.3.1(markdown-it@14.1.0):
     dependencies:

--- a/src/_layouts/article.njk
+++ b/src/_layouts/article.njk
@@ -81,3 +81,35 @@ layout: base.njk
   updateProgress();
 })();
 </script>
+
+<script>
+(() => {
+  const anchors = document.querySelectorAll('.c-heading-anchor');
+  if (!anchors.length) return;
+
+  anchors.forEach(anchor => {
+    anchor.addEventListener('click', (e) => {
+      e.preventDefault();
+      const hash = anchor.getAttribute('href');
+      const id = hash.replace(/^#/, '');
+      const target = document.getElementById(id);
+      if (!target) return;
+
+      history.replaceState(null, '', hash);
+      target.scrollIntoView({ behavior: 'smooth' });
+
+      const url = window.location.href;
+      navigator.clipboard.writeText(url).then(() => {
+        const tooltip = document.createElement('span');
+        tooltip.className = 'c-heading-anchor__tooltip';
+        tooltip.textContent = 'Copied!';
+        tooltip.setAttribute('role', 'status');
+        tooltip.setAttribute('aria-live', 'polite');
+        anchor.appendChild(tooltip);
+
+        setTimeout(() => tooltip.remove(), 1500);
+      });
+    });
+  });
+})();
+</script>

--- a/src/styles/components/_article.scss
+++ b/src/styles/components/_article.scss
@@ -133,6 +133,15 @@
 }
 
 /**
+ * Heading anchors
+ * Headings with anchors need relative positioning and scroll offset.
+ */
+.c-article__content :is(h2, h3, h4):has(> .c-heading-anchor) {
+  position: relative;
+  scroll-margin-top: var(--s-3);
+}
+
+/**
  * Links in article content
  * Only override underline offset for larger body text
  */

--- a/src/styles/components/_heading-anchor.scss
+++ b/src/styles/components/_heading-anchor.scss
@@ -1,0 +1,118 @@
+@use '../tools/mq';
+
+/*------------------------------------*\
+    # HEADING ANCHOR
+\*------------------------------------*/
+
+/**
+ * GitHub-style heading anchors for article content.
+ * Renders a link icon in the left gutter on hover,
+ * with a tooltip confirmation when the URL is copied.
+ *
+ * The anchor sits inside the heading element, so it inherits
+ * the heading's line-height. Using `height: 1lh` centres the
+ * icon against the first line of text, even for multi-line headings.
+ *
+ * On fine pointer devices (mouse), the anchor is hidden by default
+ * and revealed on heading hover/focus. On coarse pointer devices
+ * (touch), the anchor is always visible since there is no hover.
+ */
+
+.c-heading-anchor {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  left: calc(-1 * var(--s-4));
+  top: 0;
+  width: var(--s-4);
+  height: 1lh;
+  color: var(--c-text-subdued);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  text-decoration: none;
+  border-radius: 4px;
+
+  @include mq.mq($from: md) {
+    left: -36px;
+    width: 28px;
+  }
+
+  &:hover {
+    color: var(--c-text-highlight);
+    background-color: var(--c-antiflash-white);
+  }
+
+  [data-theme="dark"] &:hover {
+    background-color: var(--c-outer-space);
+  }
+}
+
+/**
+ * Headings containing an anchor need relative positioning
+ * so the absolutely-positioned anchor stays in the gutter.
+ */
+.c-article__content h2:has(.c-heading-anchor),
+.c-article__content h3:has(.c-heading-anchor),
+.c-article__content h4:has(.c-heading-anchor) {
+  position: relative;
+  scroll-margin-top: var(--s-3);
+}
+
+/**
+ * Reveal anchor on hover/focus for pointer devices.
+ */
+.c-article__content :is(h2, h3, h4):hover > .c-heading-anchor,
+.c-article__content :is(h2, h3, h4):focus-within > .c-heading-anchor,
+.c-heading-anchor:focus {
+  opacity: 1;
+}
+
+/**
+ * Always show anchors on coarse pointer (touch) devices
+ * where hover is not available.
+ */
+@media (any-pointer: coarse) {
+  .c-heading-anchor {
+    opacity: 1;
+  }
+}
+
+.c-heading-anchor__icon {
+  width: 14px;
+  height: 14px;
+
+  @include mq.mq($from: md) {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+/*------------------------------------*\
+    # HEADING ANCHOR TOOLTIP
+\*------------------------------------*/
+
+.c-heading-anchor__tooltip {
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  transform: translateX(-50%);
+  margin-top: var(--s--1);
+  padding: var(--s--1) var(--s-1);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  color: var(--c-bg);
+  background-color: var(--c-text);
+  border-radius: 4px;
+  pointer-events: none;
+  opacity: 0;
+  animation: heading-anchor-fade 1.5s ease forwards;
+}
+
+@keyframes heading-anchor-fade {
+  0% { opacity: 0; transform: translateX(-50%) translateY(-4px); }
+  15% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  85% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  100% { opacity: 0; transform: translateX(-50%) translateY(0); }
+}

--- a/src/styles/components/_heading-anchor.scss
+++ b/src/styles/components/_heading-anchor.scss
@@ -5,17 +5,20 @@
 \*------------------------------------*/
 
 /**
- * GitHub-style heading anchors for article content.
+ * GitHub-style heading anchors for content.
  * Renders a link icon in the left gutter on hover,
  * with a tooltip confirmation when the URL is copied.
  *
- * The anchor sits inside the heading element, so it inherits
+ * The anchor sits inside a heading element, so it inherits
  * the heading's line-height. Using `height: 1lh` centres the
  * icon against the first line of text, even for multi-line headings.
  *
  * On fine pointer devices (mouse), the anchor is hidden by default
  * and revealed on heading hover/focus. On coarse pointer devices
  * (touch), the anchor is always visible since there is no hover.
+ *
+ * The parent heading must have `position: relative` for the anchor
+ * to position correctly in the gutter.
  */
 
 .c-heading-anchor {
@@ -23,6 +26,10 @@
   align-items: center;
   justify-content: center;
   position: absolute;
+  /**
+   * Width matches the page gutter (article padding + grid gutter)
+   * so the icon centres within the available gutter space.
+   */
   left: calc(-1 * var(--s-4));
   top: 0;
   width: var(--s-4);
@@ -49,21 +56,10 @@
 }
 
 /**
- * Headings containing an anchor need relative positioning
- * so the absolutely-positioned anchor stays in the gutter.
+ * Reveal anchor on heading hover/focus.
  */
-.c-article__content h2:has(.c-heading-anchor),
-.c-article__content h3:has(.c-heading-anchor),
-.c-article__content h4:has(.c-heading-anchor) {
-  position: relative;
-  scroll-margin-top: var(--s-3);
-}
-
-/**
- * Reveal anchor on hover/focus for pointer devices.
- */
-.c-article__content :is(h2, h3, h4):hover > .c-heading-anchor,
-.c-article__content :is(h2, h3, h4):focus-within > .c-heading-anchor,
+:is(h2, h3, h4):hover > .c-heading-anchor,
+:is(h2, h3, h4):focus-within > .c-heading-anchor,
 .c-heading-anchor:focus {
   opacity: 1;
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -29,6 +29,7 @@
 @use 'components/archive';
 @use 'components/article';
 @use 'components/progress-bar';
+@use 'components/heading-anchor';
 
 @use 'utilities/clearfix';
 @use 'utilities/visibility';


### PR DESCRIPTION
## Summary

- Adds GitHub-style heading anchors to h2-h4 in blog articles using `markdown-it-anchor`
- Clicking an anchor updates the URL hash, smooth scrolls to the heading, and copies the permalink to clipboard with a "Copied!" tooltip
- Uses `1lh` unit to vertically centre the icon with the first line of heading text (works for multi-line headings)
- Uses `@media (any-pointer: coarse)` to always show anchors on touch devices; hidden behind hover/focus on pointer devices
- Accessible: `aria-label` on anchors, `role="status"` on tooltip, keyboard navigable

## Test plan

- [ ] `pnpm build` succeeds
- [ ] Heading IDs are generated in the DOM
- [ ] Hover a heading on desktop — link icon appears in the left gutter, centred with the first line
- [ ] Click the icon — URL updates with hash, page smooth scrolls with offset, "Copied!" tooltip appears centred below the icon
- [ ] Paste from clipboard — full URL with anchor hash
- [ ] Keyboard: Tab to anchor, Enter to activate — same behaviour
- [ ] Check dark/light theme — tooltip readable in both
- [ ] Check mobile/touch viewport — anchors always visible in the page gutter
- [ ] Check multi-line headings — icon aligns with first line

🤖 Generated with [Claude Code](https://claude.com/claude-code)