### PR TITLE
Fix heading anchor mobile sizing and toast

### DIFF
--- a/src/_layouts/article.njk
+++ b/src/_layouts/article.njk
@@ -100,14 +100,14 @@ layout: base.njk
 
       const url = window.location.href;
       navigator.clipboard.writeText(url).then(() => {
-        const tooltip = document.createElement('span');
-        tooltip.className = 'c-heading-anchor__tooltip';
-        tooltip.textContent = 'Copied!';
-        tooltip.setAttribute('role', 'status');
-        tooltip.setAttribute('aria-live', 'polite');
-        anchor.appendChild(tooltip);
+        const toast = document.createElement('span');
+        toast.className = 'c-heading-anchor__toast';
+        toast.textContent = '🔗 Link copied!';
+        toast.setAttribute('role', 'status');
+        toast.setAttribute('aria-live', 'polite');
+        document.body.appendChild(toast);
 
-        setTimeout(() => tooltip.remove(), 1500);
+        setTimeout(() => toast.remove(), 1500);
       });
     });
   });

--- a/src/styles/components/_heading-anchor.scss
+++ b/src/styles/components/_heading-anchor.scss
@@ -29,16 +29,22 @@
   /**
    * Width matches the page gutter (article padding + grid gutter)
    * so the icon centres within the available gutter space.
+   * Reduced on the smallest screens to avoid touching the viewport edge.
    */
-  left: calc(-1 * var(--s-4));
+  left: calc(-1 * var(--s-3));
   top: 0;
-  width: var(--s-4);
+  width: var(--s-3);
   height: 1lh;
   color: var(--c-text-subdued);
   opacity: 0;
   transition: opacity 0.15s ease;
   text-decoration: none;
   border-radius: 4px;
+
+  @include mq.mq($from: sm) {
+    left: calc(-1 * var(--s-4));
+    width: var(--s-4);
+  }
 
   @include mq.mq($from: md) {
     left: -36px;
@@ -85,29 +91,34 @@
 }
 
 /*------------------------------------*\
-    # HEADING ANCHOR TOOLTIP
+    # HEADING ANCHOR TOAST
 \*------------------------------------*/
 
-.c-heading-anchor__tooltip {
-  position: absolute;
+/**
+ * Toast notification shown at the bottom of the viewport
+ * when a heading link is copied to clipboard.
+ */
+
+.c-heading-anchor__toast {
+  position: fixed;
+  bottom: var(--s-3);
   left: 50%;
-  top: 100%;
   transform: translateX(-50%);
-  margin-top: var(--s--1);
-  padding: var(--s--1) var(--s-1);
-  font-size: 12px;
+  padding: var(--s-1) var(--s-2);
+  font-size: 14px;
   line-height: 1;
   white-space: nowrap;
   color: var(--c-bg);
   background-color: var(--c-text);
   border-radius: 4px;
   pointer-events: none;
+  z-index: 1;
   opacity: 0;
-  animation: heading-anchor-fade 1.5s ease forwards;
+  animation: heading-anchor-toast 1.5s ease forwards;
 }
 
-@keyframes heading-anchor-fade {
-  0% { opacity: 0; transform: translateX(-50%) translateY(-4px); }
+@keyframes heading-anchor-toast {
+  0% { opacity: 0; transform: translateX(-50%) translateY(var(--s-1)); }
   15% { opacity: 1; transform: translateX(-50%) translateY(0); }
   85% { opacity: 1; transform: translateX(-50%) translateY(0); }
   100% { opacity: 0; transform: translateX(-50%) translateY(0); }


### PR DESCRIPTION
## Summary

Follow-up to #25 fixing two mobile issues:

- Reduce anchor hit area on smallest screens (`var(--s-3)` / 24px) to avoid touching the viewport edge and heading text, scaling up at `sm` breakpoint
- Replace the absolutely-positioned tooltip with a fixed-position toast centred at the bottom of the viewport — prevents clipping on mobile and works consistently across all breakpoints
- Rename CSS class from `__tooltip` to `__toast` to reflect the new pattern

## Test plan

- [ ] Mobile: anchor icon has breathing room from viewport edge and heading text
- [ ] Mobile: tapping anchor shows "🔗 Link copied!" toast at bottom centre of screen
- [ ] Tablet: toast displays correctly
- [ ] Desktop: toast displays correctly, anchor hover states unchanged
- [ ] Toast auto-dismisses after 1.5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)